### PR TITLE
Fix: Long HexStrings cause a `RangeError` (js recursion)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
     "purescript-transformers": "v3.4.0",
     "purescript-identity": "v3.1.0",
     "purescript-aff": "v4.0.0",
-    "purescript-tagged": "^1.0.0"
+    "purescript-tagged": "^1.0.0",
+    "purescript-free": "^4.2.0"
   },
   "devDependencies": {
     "purescript-debug": "v3.0.0",

--- a/src/Network/Ethereum/Web3/Types/Types.purs
+++ b/src/Network/Ethereum/Web3/Types/Types.purs
@@ -49,6 +49,7 @@ import Control.Monad.Eff (kind Effect)
 import Control.Monad.Eff.Class (class MonadEff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Error.Class (class MonadThrow, catchError)
+import Control.Monad.Trampoline (runTrampoline)
 import Data.Array (many)
 import Data.Foreign (readBoolean, Foreign, F)
 import Data.Foreign.Class (class Decode, class Encode, encode, decode)
@@ -65,7 +66,7 @@ import Data.String (length, take) as S
 import Data.String (stripPrefix, Pattern(..), fromCharArray)
 import Network.Ethereum.Web3.Types.BigNumber (BigNumber)
 import Network.Ethereum.Web3.Types.EtherUnit (Value, Wei)
-import Text.Parsing.Parser (runParser)
+import Text.Parsing.Parser (runParserT)
 import Text.Parsing.Parser.Token (hexDigit)
 
 --------------------------------------------------------------------------------
@@ -132,7 +133,8 @@ mkHexString str = HexString <$>
     Nothing -> go str
     Just res -> go res
   where
-    go s = hush $ runParser s (fromCharArray <$> many hexDigit)
+    go s = hush $ runTrampParser s (fromCharArray <$> many hexDigit)
+    runTrampParser s = runTrampoline <<< runParserT s
 
 -- | Compute the length of the hex string, which is twice the number of bytes it represents
 hexLength :: HexString -> Int

--- a/test/Web3Spec/Encoding/Simple.purs
+++ b/test/Web3Spec/Encoding/Simple.purs
@@ -6,8 +6,10 @@ import Prelude
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Except (runExcept, runExceptT)
+import Data.Array (replicate)
 import Data.ByteString as BS
 import Data.Either (Either(..))
+import Data.Foldable (intercalate)
 import Data.Foreign (ForeignError(..))
 import Data.Foreign.Generic (decodeJSON, defaultOptions, genericDecodeJSON)
 import Data.Identity (Identity(..))
@@ -19,7 +21,7 @@ import Network.Ethereum.Web3.Solidity.Bytes (BytesN, fromByteString)
 import Network.Ethereum.Web3.Solidity.Int (IntN, intNFromBigNumber)
 import Network.Ethereum.Web3.Solidity.Size (D1, D2, D3, D4, D5, D6, D8, type (:&))
 import Network.Ethereum.Web3.Solidity.UInt (UIntN, uIntNFromBigNumber)
-import Network.Ethereum.Web3.Types (FalseOrObject(..), HexString, SyncStatus(..), decimal, embed, mkAddress, mkHexString, parseBigNumber, pow, (+<), (-<))
+import Network.Ethereum.Web3.Types (FalseOrObject(..), HexString, SyncStatus(..), decimal, embed, mkAddress, mkHexString, parseBigNumber, pow, unHex, (+<), (-<))
 import Partial.Unsafe (unsafePartial)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
@@ -65,6 +67,13 @@ stringTests =
                                 <> "c383c2a4c383c2a4000000000000000000000000000000000000000000000000"
 
         roundTrip given expected
+
+    
+      it "can handle VERY long HexStrings" do
+        let given = intercalate "" $ replicate 1024 "0000000000000000000000000000000000000000000000000000000000000000"
+        let expected = unsafePartial fromJust <<< mkHexString $ given
+        given `shouldEqual` unHex expected
+
 
 bytesDTests :: forall r . Spec r Unit
 bytesDTests =

--- a/test/Web3Spec/Encoding/Simple.purs
+++ b/test/Web3Spec/Encoding/Simple.purs
@@ -70,7 +70,7 @@ stringTests =
 
     
       it "can handle VERY long HexStrings" do
-        let given = intercalate "" $ replicate 1024 "0000000000000000000000000000000000000000000000000000000000000000"
+        let given = intercalate "" $ replicate 128 "0000000000000000000000000000000000000000000000000000000000000000"
         let expected = unsafePartial fromJust <<< mkHexString $ given
         given `shouldEqual` unHex expected
 


### PR DESCRIPTION
While publishing some contract code I noticed `mkHexString` will fail on long strings. (E.g. mine is 7332 chars including `0x`).

Particular error is: `RangeError: Maximum call stack size exceeded`

I've added a test showing the failing case. Implemented a solution like: https://github.com/purescript-contrib/purescript-parsing/issues/34

It works, but see my comment further down regarding speed.