### PR TITLE
Remove Block.mixHash - not in JSON-RPC spec

### DIFF
--- a/src/Network/Ethereum/Web3/Types/Types.purs
+++ b/src/Network/Ethereum/Web3/Types/Types.purs
@@ -188,7 +188,6 @@ newtype Block
           , hash :: HexString
           , logsBloom :: HexString
           , miner :: HexString
-          , mixHash :: HexString
           , nonce :: HexString
           , number :: BigNumber
           , parentHash :: HexString


### PR DESCRIPTION
This is a breaking change if anyone is relying on Block.mixHash - but it's not in the JSON-RPC spec so I think it should be removed.

An alternative is to make it a `NullOrUndefined`

JSON-RPC Spec: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbyhash

Geth does add `mixHash` to the response, but since it's not in the spec TestRPC does not. I think it's appropriate to remove it completely.