### PR TITLE
Add caching to travis to improve build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ install:
   - npm install
 script:
   - npm -s test
+cache:
+  yarn: true
+  directories:
+    - node-modules
+    - output
+    - .pulp-cache
+    - bower_components


### PR DESCRIPTION
I've previously used these caches to improve build times on travis for purescript modules.