### PR TITLE
Add `Newtype` derivation to `Block`

### DIFF
--- a/src/Network/Ethereum/Web3/Types/Types.purs
+++ b/src/Network/Ethereum/Web3/Types/Types.purs
@@ -250,6 +250,7 @@ newtype Block
           }
 
 derive instance genericBlock :: Generic Block _
+derive instance newtypeBlock :: Newtype Block _
 derive instance eqBlock :: Eq Block
 
 instance showBlock :: Show Block where

--- a/src/Network/Ethereum/Web3/Types/Types.purs
+++ b/src/Network/Ethereum/Web3/Types/Types.purs
@@ -113,9 +113,7 @@ instance hexStringEq :: Eq HexString where
   eq (HexString h1) (HexString h2) = S.toLower h1 == S.toLower h2
 
 derive newtype instance hexStringOrd :: Ord HexString
-
 derive newtype instance semigpStringEq :: Semigroup HexString
-
 derive newtype instance monoidStringEq :: Monoid HexString
 
 instance decodeHexString :: Decode HexString where
@@ -166,13 +164,9 @@ takeHex n (HexString hx) = HexString $ S.take n hx
 newtype Address = Address HexString
 
 derive newtype instance addressShow :: Show Address
-
 derive newtype instance addressEq :: Eq Address
-
 derive newtype instance addressOrd :: Ord Address
-
 derive newtype instance decodeAddress :: Decode Address
-
 derive newtype instance encodeAddress :: Encode Address
 
 unAddress :: Address -> HexString
@@ -278,6 +272,7 @@ newtype Transaction =
               }
 
 derive instance genericTransaction :: Generic Transaction _
+derive instance newtypeTransaction :: Newtype Transaction _
 derive instance eqTransaction :: Eq Transaction
 
 instance showTransaction :: Show Transaction where
@@ -302,6 +297,7 @@ newtype TransactionReceipt =
                      }
 
 derive instance genericTxReceipt :: Generic TransactionReceipt _
+derive instance newtypeTxReceipt :: Newtype TransactionReceipt _
 derive instance eqTxReceipt :: Eq TransactionReceipt
 
 instance showTxReceipt :: Show TransactionReceipt where
@@ -325,6 +321,8 @@ newtype TransactionOptions =
                      }
 
 derive instance genericTransactionOptions :: Generic TransactionOptions _
+derive instance newtypeTransactionOptions :: Newtype TransactionOptions _
+derive instance eqTransactionOptions :: Eq TransactionOptions
 
 instance showTransactionOptions :: Show TransactionOptions where
   show = genericShow
@@ -383,6 +381,7 @@ newtype SyncStatus = SyncStatus
     }
 
 derive instance genericSyncStatus :: Generic SyncStatus _
+derive instance newtypeSyncStatus :: Newtype SyncStatus _
 derive instance eqSyncStatus :: Eq SyncStatus
 
 instance decodeSyncStatus :: Decode SyncStatus where
@@ -435,6 +434,7 @@ newtype Filter = Filter
   }
 
 derive instance genericFilter :: Generic Filter _
+derive instance newtypeFilter :: Newtype Filter _
 
 instance showFilter :: Show Filter where
   show = genericShow
@@ -523,6 +523,7 @@ newtype Change = Change
   }
 
 derive instance genericChange :: Generic Change _
+derive instance newtypeChange :: Newtype Change _
 
 instance showChange :: Show Change where
   show = genericShow

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,17 +1,19 @@
 module Test.Main where
 
 import Prelude
+
 import Control.Monad.Eff (Eff)
-import Web3Spec.Types.Sha3 (sha3Spec)
-import Web3Spec.Types.Utils (utilsSpec)
-import Web3Spec.Types.BigNumber (bigNumberSpec)
-import Web3Spec.Encoding.Simple (encodingSimpleSpec)
-import Web3Spec.Encoding.Generic (encodingGenericSpec)
-import Web3Spec.Encoding.Containers (encodingContainersSpec)
-import Web3Spec.Contract (simpleStorageSpec)
+import Network.Ethereum.Web3.Types (ETH)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (RunnerEffects, run)
-import Network.Ethereum.Web3.Types (ETH)
+import Web3Spec.Contract (simpleStorageSpec)
+import Web3Spec.Encoding.Containers (encodingContainersSpec)
+import Web3Spec.Encoding.Generic (encodingGenericSpec)
+import Web3Spec.Encoding.Simple (encodingSimpleSpec)
+import Web3Spec.Types.BigNumber (bigNumberSpec)
+import Web3Spec.Types.Newtypes (ntTests)
+import Web3Spec.Types.Sha3 (sha3Spec)
+import Web3Spec.Types.Utils (utilsSpec)
 
 main :: Eff (RunnerEffects (eth :: ETH)) Unit
 main = run [consoleReporter] $ do
@@ -22,4 +24,4 @@ main = run [consoleReporter] $ do
   encodingSimpleSpec
   encodingGenericSpec
   simpleStorageSpec
-
+  ntTests

--- a/test/Web3Spec/Types/Newtypes.purs
+++ b/test/Web3Spec/Types/Newtypes.purs
@@ -1,0 +1,76 @@
+module Web3Spec.Types.Newtypes (ntTests) where
+
+import Prelude
+
+import Control.Monad.Aff (Aff, Error)
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Error.Class (try)
+import Data.Array (head)
+import Data.Either (Either)
+import Data.Maybe (Maybe(..), fromJust)
+import Data.Newtype (class Newtype, unwrap, wrap)
+import Network.Ethereum.Web3 (class IsAsyncProvider, Block(..), ChainCursor(..), HexString, Web3, defaultFilter, defaultTransactionOptions, httpProvider, mkHexString, runWeb3)
+import Network.Ethereum.Web3.Api (eth_blockNumber, eth_getBlockByNumber, eth_getFilterChanges, eth_getSyncing, eth_getTransaction, eth_getTransactionReceipt, eth_newFilter)
+import Network.Ethereum.Web3.Types (FalseOrObject(..))
+import Partial.Unsafe (unsafePartial)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+import Type.Proxy (Proxy(..))
+
+-- Set up HTTP provider for testing, note, this doesn't
+-- need to actually work, just needs to typecheck
+data HttpProvider
+
+http :: Proxy HttpProvider
+http = Proxy
+
+instance isAsyncHttp :: IsAsyncProvider HttpProvider where
+  getAsyncProvider = liftEff <<< httpProvider $ "http://localhost:8545"
+
+runWeb3_ = runWeb3 http
+
+-- note: this does not need to work, just typecheck
+runNtTest :: forall a r. Newtype a _ => Web3 _ _ a -> Aff _ (Either Error a)
+runNtTest web3req = try $ wrap <$> unwrap <$> runWeb3_ web3req
+
+
+fakeTxid :: HexString
+fakeTxid = unsafePartial fromJust $ mkHexString "00"
+
+
+-- | tests that typecheck if these types derive newtype
+ntTests :: forall r . Spec _ Unit
+ntTests = describe "newtype-tests" do
+    it "Block should derive newtype" $ do
+        _ <- runNtTest $ eth_getBlockByNumber Latest
+        pure unit
+
+    it "Transaction should derive newtype" $ do
+        _ <- runNtTest $ eth_getTransaction fakeTxid
+        pure unit
+
+    it "TransactionReceipt should derive newtype" $ do
+        _ <- runNtTest $ eth_getTransactionReceipt fakeTxid
+        pure unit
+
+    it "TransactionOptions should derive newtype" $ do
+        let _ = unwrap defaultTransactionOptions
+        pure unit
+
+    it "SyncStatus should derive newtype" $ do
+        _ <- runNtTest eth_getSyncing
+        pure unit
+
+    it "Filter should derive newtype" $ do
+        let _ = unwrap defaultFilter
+        pure unit
+
+    it "Change should derive newtype" $ do
+        _ <- try $ runWeb3_ $ do
+            fId <- eth_newFilter defaultFilter
+            (map $ unwrap) <$> eth_getFilterChanges fId
+        pure unit
+
+    it "FalseOrObject should derive newtype" $ do
+        let _ = unwrap $ FalseOrObject Nothing
+        pure unit


### PR DESCRIPTION
Since we don't have lenses on `Block` fields a `Newtype` instance let's us use `unwrap` and the like.

Not sure if we had this before or not, but noticed it was missing now.