### PR TITLE
Fix badly formed `eth_getBlockByHash` request

### DIFF
--- a/src/Network/Ethereum/Web3/Api.purs
+++ b/src/Network/Ethereum/Web3/Api.purs
@@ -139,7 +139,7 @@ eth_getBlockByNumber cm = unsafeCoerceWeb3 $ remote "eth_getBlockByNumber" cm fa
 
 -- | Returns information about a block by hash.
 eth_getBlockByHash :: forall p e . IsAsyncProvider p => HexString -> Web3 p e Block
-eth_getBlockByHash hx = unsafeCoerceWeb3 $ remote "eth_getBlockByHash" hx :: Web3 p () Block
+eth_getBlockByHash hx = unsafeCoerceWeb3 $ remote "eth_getBlockByHash" hx false :: Web3 p () Block
 
 -- | Returns information about a transaction by hash.
 eth_getTransaction :: forall p e . IsAsyncProvider p => HexString -> Web3 p e Transaction


### PR DESCRIPTION
the `eth_getBlockByHash` method didn't include the second parameter. This throws an error with parity and crashes testrpc/ganache.

See https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbyhash for spec.