### PR TITLE
remove ./node_modules/.bin from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lib": "./src"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/psc-package update",
+    "postinstall": "psc-package update",
     "test": "pulp --psc-package test"
   },
   "dependencies": {


### PR DESCRIPTION
there is no need for this prefix here as npm adds it to PATH when script is executed