### PR TITLE
dont throw remote exceptions into the aether

### DIFF
--- a/src/Network/Ethereum/Web3/Types/Types.purs
+++ b/src/Network/Ethereum/Web3/Types/Types.purs
@@ -583,6 +583,8 @@ instance decodeRpcError :: Decode RpcError where
 
 data Web3Error =
     Rpc RpcError
+  | RemoteError String
+  | ParserError String
   | NullError
 
 derive instance genericWeb3Error :: Generic Web3Error _


### PR DESCRIPTION
Add a `RemoteError` and `ParserError` constructors to `Web3Error`, so remote exceptions can be gracefully handled.