### PR TITLE
fix _sendAsync canceler

### DIFF
--- a/src/Network/Ethereum/Web3/JsonRPC.js
+++ b/src/Network/Ethereum/Web3/JsonRPC.js
@@ -4,15 +4,18 @@
 exports._sendAsync = function (provider) {
     return function (request) {
         return function(onError, onSuccess) {
-            var cancel = provider.sendAsync(request, function(err, succ) {
-                if (err) {
+            var canceled = false;
+            provider.sendAsync(request, function(err, succ) {
+                if (canceled) {
+                    return;
+                } else if (err) {
                     onError(err);
                 } else {
                     onSuccess(succ);
                 }
             });
             return function (cancelError, onCancelerError, onCancelerSuccess) {
-                cancel();
+                canceled = true;
                 onCancelerSuccess();
             };
         };

--- a/src/Network/Ethereum/Web3/JsonRPC.js
+++ b/src/Network/Ethereum/Web3/JsonRPC.js
@@ -4,18 +4,14 @@
 exports._sendAsync = function (provider) {
     return function (request) {
         return function(onError, onSuccess) {
-            var canceled = false;
             provider.sendAsync(request, function(err, succ) {
-                if (canceled) {
-                    return;
-                } else if (err) {
+                if (err) {
                     onError(err);
                 } else {
                     onSuccess(succ);
                 }
             });
             return function (cancelError, onCancelerError, onCancelerSuccess) {
-                canceled = true;
                 onCancelerSuccess();
             };
         };


### PR DESCRIPTION
HttpProvider.prototype.sendAsync returns undefined so we can't cancel it.
https://github.com/ethereum/web3.js/blob/develop/lib/web3/httpprovider.js#L114-L141