### PR TITLE
Filters trail by

### DIFF
--- a/src/Network/Ethereum/Web3/Contract.purs
+++ b/src/Network/Ethereum/Web3/Contract.purs
@@ -23,10 +23,10 @@ import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Effect.Exception (error)
 import Network.Ethereum.Core.Keccak256 (toSelector)
 import Network.Ethereum.Types (Address, HexString)
-import Network.Ethereum.Web3.Api (eth_call, eth_sendTransaction)
-import Network.Ethereum.Web3.Contract.Events (reduceEventStream, logsStream, mkBlockNumber, FilterStreamState, ChangeReceipt, EventHandler)
+import Network.Ethereum.Web3.Api (eth_call, eth_sendTransaction, eth_blockNumber)
+import Network.Ethereum.Web3.Contract.Events (reduceEventStream, logsStream, FilterStreamState, ChangeReceipt, EventHandler)
 import Network.Ethereum.Web3.Solidity (class DecodeEvent, class GenericABIDecode, class GenericABIEncode, class RecordFieldsIso, genericABIEncode, genericFromData, genericFromRecordFields)
-import Network.Ethereum.Web3.Types (class TokenUnit, CallError(..), ChainCursor, ETHER, Filter, NoPay, TransactionOptions, Value, Web3, _data, _fromBlock, _value, convert, throwWeb3)
+import Network.Ethereum.Web3.Types (class TokenUnit, CallError(..), ChainCursor(..), ETHER, Filter, NoPay, TransactionOptions, Value, Web3, _data, _fromBlock, _value, convert, throwWeb3)
 import Type.Proxy (Proxy)
 
 --------------------------------------------------------------------------------
@@ -58,7 +58,9 @@ event' :: forall e i ni.
        -> EventHandler Web3 e
        -> Web3 (Either (FilterStreamState e) ChangeReceipt)
 event' initialFilter {windowSize, trailBy} handler = do
-  currentBlock <- mkBlockNumber $ initialFilter ^. _fromBlock
+  currentBlock <- case initialFilter ^. _fromBlock of
+    BN bn -> pure bn
+    Latest -> eth_blockNumber
   let initialState = { currentBlock
                      , initialFilter
                      , windowSize

--- a/src/Network/Ethereum/Web3/Contract.purs
+++ b/src/Network/Ethereum/Web3/Contract.purs
@@ -43,7 +43,7 @@ event :: forall e i ni.
       => Filter e
       -> EventHandler Web3 e
       -> Web3 (Either (FilterStreamState e) ChangeReceipt)
-event fltr handler = event' fltr zero handler
+event fltr handler = event' fltr {windowSize: 0, trailBy: 0} handler
 
 
 -- | Takes a `Filter` and a handler, as well as a windowSize.
@@ -52,14 +52,17 @@ event fltr handler = event' fltr zero handler
 event' :: forall e i ni.
           DecodeEvent i ni e
        => Filter e
-       -> Int
+       -> { windowSize :: Int
+          , trailBy :: Int
+          }
        -> EventHandler Web3 e
        -> Web3 (Either (FilterStreamState e) ChangeReceipt)
-event' fltr w handler = do
-  currentBlock <- mkBlockNumber $ fltr ^. _fromBlock
+event' initialFilter {windowSize, trailBy} handler = do
+  currentBlock <- mkBlockNumber $ initialFilter ^. _fromBlock
   let initialState = { currentBlock
-                     , initialFilter: fltr
-                     , windowSize: w
+                     , initialFilter
+                     , windowSize
+                     , trailBy
                      }
   runProcess $ reduceEventStream (logsStream initialState) handler
 

--- a/src/Network/Ethereum/Web3/Contract/Events.purs
+++ b/src/Network/Ethereum/Web3/Contract/Events.purs
@@ -98,10 +98,6 @@ filterProducer currentState = do
            in if currentState.currentBlock <= targetEnd'
                 then continueTo targetEnd'
                 else pure currentState
-<<<<<<< HEAD
-         -- otherwsie we're in Earliest, which is a degenerate case
-=======
->>>>>>> 186d66e... added trailBy, remove Earliest and Pending
   where
     newTo :: BlockNumber -> BlockNumber -> Int -> BlockNumber
     newTo upper current window = min upper (wrap $ unwrap current + embed window)

--- a/src/Network/Ethereum/Web3/Types/Types.purs
+++ b/src/Network/Ethereum/Web3/Types/Types.purs
@@ -104,8 +104,6 @@ instance writeFHexString :: WriteForeign BlockNumber where
 -- | Refers to a particular block time, used when making calls, transactions, or watching for events.
 data ChainCursor =
     Latest
-  | Pending
-  | Earliest
   | BN BlockNumber
 
 derive instance genericChainCursor :: Generic ChainCursor _
@@ -117,21 +115,14 @@ instance showChainCursor :: Show ChainCursor where
   show = genericShow
 
 instance ordChainCursor :: Ord ChainCursor where
-  compare Pending Pending = EQ
   compare Latest Latest = EQ
-  compare Earliest Earliest = EQ
   compare (BN a) (BN b) = compare a b
-  compare _ Pending = LT
-  compare Pending Latest = GT
   compare _ Latest = LT
-  compare Earliest _ = LT
   compare a b = invert $ compare b a
 
 instance encodeChainCursor :: Encode ChainCursor where
   encode cm = case cm of
     Latest -> encode "latest"
-    Pending -> encode "pending"
-    Earliest -> encode "earliest"
     BN n -> encode n
 
 newtype Block

--- a/test/web3/Main.purs
+++ b/test/web3/Main.purs
@@ -29,7 +29,7 @@ import Web3Spec.Types.VectorSpec as VectorSpec
 
 main :: Effect Unit
 main = launchAff_ do
-  let cfg = defaultConfig {timeout = Just (Milliseconds $ 60.0 * 1000.0)}
+  let cfg = defaultConfig {timeout = Just (Milliseconds $ 120.0 * 1000.0)}
   p <- liftEffect $ httpProvider "http://localhost:8545"
   join $ runSpecT cfg [consoleReporter] do
     hoist do

--- a/test/web3/Web3Spec/Live/FilterSpec.purs
+++ b/test/web3/Web3Spec/Live/FilterSpec.purs
@@ -11,13 +11,12 @@ import Data.Newtype (wrap, unwrap, un)
 import Data.Ord.Down (Down(..))
 import Data.Traversable (traverse_)
 import Data.Lens ((?~), (.~), (^.))
-import Data.Tuple (Tuple(..), fst, snd)
 import Effect.Aff (Aff, Fiber, error)
 import Effect.Class (liftEffect)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Aff.AVar as AVar
 import Effect.AVar as EAVar
-import Network.Ethereum.Web3 (BlockNumber(..), throwWeb3, Filter, Web3Error, Change(..), _fromBlock, _toBlock, eventFilter, EventAction(..), forkWeb3, event, ChainCursor(..), Provider, UIntN, _from, _to, embed, Address, event')
+import Network.Ethereum.Web3 (BlockNumber(..), throwWeb3, Filter, Web3Error, Change(..), _fromBlock, _toBlock, eventFilter, EventAction(..), forkWeb3, ChainCursor(..), Provider, UIntN, _from, _to, embed, Address, event')
 import Network.Ethereum.Web3.Api as Api
 import Network.Ethereum.Web3.Solidity.Sizes (s256, S256)
 import Partial.Unsafe (unsafeCrashWith)

--- a/test/web3/Web3Spec/Live/FilterSpec.purs
+++ b/test/web3/Web3Spec/Live/FilterSpec.purs
@@ -3,21 +3,21 @@ module Web3Spec.Live.FilterSpec (spec) where
 import Prelude
 
 import Control.Monad.Reader (ask)
+import Control.Monad.Trans.Class (lift)
 import Data.Array ((..), snoc, length, head, sortWith)
 import Data.Either (Either)
 import Data.Maybe (Maybe(..))
-import Data.Newtype (wrap, unwrap)
+import Data.Newtype (wrap, unwrap, un)
 import Data.Ord.Down (Down(..))
 import Data.Traversable (traverse_)
 import Data.Lens ((?~), (.~), (^.))
-import Effect.Aff (Aff, Fiber)
+import Data.Tuple (Tuple(..), fst, snd)
+import Effect.Aff (Aff, Fiber, error)
 import Effect.Class (liftEffect)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Aff.AVar as AVar
 import Effect.AVar as EAVar
-import Effect.Class.Console as C
-import Effect.Unsafe (unsafePerformEffect)
-import Network.Ethereum.Web3 (BlockNumber, Filter, Web3Error, Change(..), _fromBlock, _toBlock, eventFilter, EventAction(..), forkWeb3, event, ChainCursor(..), Provider, UIntN, _from, _to, embed, Address)
+import Network.Ethereum.Web3 (BlockNumber(..), throwWeb3, Filter, Web3Error, Change(..), _fromBlock, _toBlock, eventFilter, EventAction(..), forkWeb3, event, ChainCursor(..), Provider, UIntN, _from, _to, embed, Address, event')
 import Network.Ethereum.Web3.Api as Api
 import Network.Ethereum.Web3.Solidity.Sizes (s256, S256)
 import Partial.Unsafe (unsafeCrashWith)
@@ -40,6 +40,8 @@ type FilterEnv m =
   }
 
 {-
+NOTE: none of the Futures use Pending, the behavior is currently ill defined
+
 Case [Past,Past] : The filter is starting and ending in the past.
 Case [Past, ∞] : The filter starts in the past but continues indefinitely into the future.
 Case [Future, ∞] : The fitler starts in the future and continues indefinitely into the future.
@@ -54,16 +56,16 @@ spec'
   -> SpecT m Unit Aff Unit
 spec' provider {logger} = do
   uIntV <- liftEffect $ EAVar.new 1
-  let uIntsGen = mkUIntsGen uIntV
+  let gen = mkUIntsGen uIntV
   describe "Filters" $ parallel do
 
-    before (deployUniqueSimpleStorage provider logger) $
+    before (deployUniqueSimpleStorage provider logger gen) $
       it "Case [Past, Past]" \simpleStorageCfg -> do
-        let {simpleStorageAddress, setter} = simpleStorageCfg
+        let {simpleStorageAddress, setter, uIntsGen} = simpleStorageCfg
             filter = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
         values <- uIntsGen 3
         logger $ "Searching for values " <> show values
-        fiber <- monitorUntil provider logger filter (_ == aMax values)
+        fiber <- monitorUntil provider logger filter (_ == aMax values) defaultFilterOpts
         start <- assertWeb3 provider Api.eth_blockNumber
         traverse_ setter values
         {endingBlockV} <- joinWeb3Fork fiber
@@ -71,35 +73,20 @@ spec' provider {logger} = do
         let pastFilter = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
                            # _fromBlock .~ BN start
                            # _toBlock .~  BN end
-        fiber' <- monitorUntil provider logger pastFilter (const false)
+        fiber' <- monitorUntil provider logger pastFilter (const false) defaultFilterOpts
         {foundValuesV} <- joinWeb3Fork fiber'
         foundValues <- liftAff $ AVar.take foundValuesV
         liftAff $ foundValues `shouldEqual` values
 
-    before (deployUniqueSimpleStorage provider logger) $
-      it "Case [Past, ∞]" \simpleStorageCfg -> do
-        let {simpleStorageAddress, setter} = simpleStorageCfg
-            filter1 = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
-        firstValues <- uIntsGen 3
-        secondValues <- uIntsGen 3
-        let allValues = firstValues <> secondValues
-        logger $ "Searching for values " <> show allValues
-        fiber1 <- monitorUntil provider logger filter1 (_ == aMax firstValues)
-        start <- assertWeb3 provider Api.eth_blockNumber
-        traverse_ setter firstValues
-        _ <- joinWeb3Fork fiber1
-        let filter2 = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
-                         # _fromBlock .~ BN start
-                         # _toBlock   .~ Latest
-        fiber2 <- monitorUntil provider logger filter2 (_ == aMax secondValues)
-        traverse_ setter secondValues
-        {foundValuesV} <- joinWeb3Fork fiber2
-        foundValues <- liftAff $ AVar.take foundValuesV
-        liftAff $ foundValues `shouldEqual` allValues
+    before (deployUniqueSimpleStorage provider logger gen) $ do
+      it "Case [Past, ∞] No Trail" \simpleStorageCfg -> do
+        fromPastToFutureTrailingBy simpleStorageCfg provider logger defaultFilterOpts
+      it "Case [Past, ∞] With Trail" \simpleStorageCfg -> do
+        fromPastToFutureTrailingBy simpleStorageCfg provider logger {trailBy: 3, windowSize: 2}
 
-    before (deployUniqueSimpleStorage provider logger) $
+    before (deployUniqueSimpleStorage provider logger gen) $
       it "Case [Future, ∞]" \simpleStorageCfg -> do
-        let {simpleStorageAddress, setter} = simpleStorageCfg
+        let {simpleStorageAddress, setter, uIntsGen} = simpleStorageCfg
         values <- uIntsGen 3
         logger $ "Searching for values " <> show values
         now <- assertWeb3 provider Api.eth_blockNumber
@@ -107,16 +94,16 @@ spec' provider {logger} = do
             filter = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
                          # _fromBlock .~ BN later
                          # _toBlock   .~ Latest
-        fiber <- monitorUntil provider logger filter (_ == aMax values)
+        fiber <- monitorUntil provider logger filter (_ == aMax values) defaultFilterOpts
         hangOutTillBlock provider logger later
         traverse_ setter values
         {foundValuesV} <- joinWeb3Fork fiber
         foundValues <- liftAff $ AVar.take foundValuesV
         liftAff $ foundValues `shouldEqual` values
 
-    before (deployUniqueSimpleStorage provider logger) $
+    before (deployUniqueSimpleStorage provider logger gen) $
       it "Case [Future, Future]" \simpleStorageCfg -> do
-        let {simpleStorageAddress, setter} = simpleStorageCfg
+        let {simpleStorageAddress, setter, uIntsGen} = simpleStorageCfg
         values <- uIntsGen 3
         logger $ "Searching for values " <> show values
         let nValues = length values
@@ -127,7 +114,7 @@ spec' provider {logger} = do
             filter = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
                        # _fromBlock .~ BN later
                        # _toBlock   .~ BN latest
-        fiber <- monitorUntil provider logger filter (_ == aMax values)
+        fiber <- monitorUntil provider logger filter (_ == aMax values) defaultFilterOpts
         hangOutTillBlock provider logger later
         traverse_ setter values
         {foundValuesV} <- joinWeb3Fork fiber
@@ -138,6 +125,43 @@ spec' provider {logger} = do
 -- Utils
 --------------------------------------------------------------------------------
 
+type FilterOpts =
+  { trailBy :: Int
+  , windowSize :: Int
+  }
+
+defaultFilterOpts :: FilterOpts
+defaultFilterOpts = {trailBy: 0, windowSize: 0}
+
+fromPastToFutureTrailingBy
+  :: forall m.
+     MonadAff m
+  => SimpleStorageCfg m
+  -> Provider
+  -> Logger m
+  -> FilterOpts
+  -> m Unit
+fromPastToFutureTrailingBy simpleStorageCfg provider logger opts = do
+  let {simpleStorageAddress, setter, uIntsGen} = simpleStorageCfg
+      filter1 = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
+  firstValues <- uIntsGen 7
+  secondValues <- uIntsGen 7
+  let allValues = firstValues <> secondValues
+  logger $ "Searching for values " <> show allValues
+  fiber1 <- monitorUntil provider logger filter1 (_ == aMax firstValues) defaultFilterOpts
+  start <- assertWeb3 provider Api.eth_blockNumber
+  traverse_ setter firstValues
+  _ <- joinWeb3Fork fiber1
+  let filter2 = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
+                   # _fromBlock .~ BN start
+                   # _toBlock   .~ Latest
+  fiber2 <- monitorUntil provider logger filter2 (_ == aMax secondValues) opts
+  traverse_ setter secondValues
+  {foundValuesV} <- joinWeb3Fork fiber2
+  foundValues <- liftAff $ AVar.take foundValuesV
+  liftAff $ foundValues `shouldEqual` allValues
+
+
 monitorUntil
   :: forall m.
      MonadAff m
@@ -145,6 +169,7 @@ monitorUntil
   -> Logger m
   -> Filter SimpleStorage.CountSet
   -> (UIntN S256 -> Boolean)
+  -> FilterOpts
   -> m
        ( Fiber
          ( Either Web3Error
@@ -153,36 +178,47 @@ monitorUntil
              }
          )
        )
-monitorUntil provider logger filter p = do
+monitorUntil provider logger filter p opts = do
   endingBlockV <- liftAff AVar.empty
   foundValuesV <- liftAff $ AVar.new []
   logger $ "Creating filter with fromBlock=" <> 
     show (filter ^. _fromBlock) <> " toBlock=" <> show (filter ^. _toBlock)
   liftAff $ forkWeb3 provider $ do
-    _ <- event filter \(SimpleStorage.CountSet {_count}) -> do
-      Change c <- ask
+    _ <- event' filter opts \(SimpleStorage.CountSet {_count}) -> do
+      change@(Change c) <- ask
+      chainHead <- lift Api.eth_blockNumber
+      when (un BlockNumber chainHead - un BlockNumber c.blockNumber < embed opts.trailBy) $
+        lift $ throwWeb3 $ error "Exceded max trailBy"
       foundSoFar <- liftAff $ AVar.take foundValuesV
       liftAff $ AVar.put (foundSoFar `snoc` _count) foundValuesV
-      if p _count
+      let shouldTerminate = p _count
+      if shouldTerminate
         then do
           liftAff $ AVar.put c.blockNumber endingBlockV
           pure TerminateEvent
         else pure ContinueEvent
     pure {endingBlockV, foundValuesV}
 
+
+type SimpleStorageCfg m = 
+  { simpleStorageAddress :: Address
+  , setter :: UIntN S256 -> m Unit
+  , uIntsGen :: Int -> m (Array (UIntN S256))
+  } 
+
 deployUniqueSimpleStorage
   :: forall m.
      MonadAff m
   => Provider
   -> Logger m
-  -> m { simpleStorageAddress :: Address
-       , setter :: UIntN S256 -> m Unit
-       } 
-deployUniqueSimpleStorage provider logger = do
+  -> (Int -> m (Array (UIntN S256)))
+  -> m (SimpleStorageCfg m)
+deployUniqueSimpleStorage provider logger uIntsGen = do
   contractConfig <- deployContract provider logger "SimpleStorage" $ \txOpts ->
     SimpleStorage.constructor txOpts SimpleStorageCode.deployBytecode
   pure { simpleStorageAddress: contractConfig.contractAddress
        , setter: mkSetter contractConfig provider logger
+       , uIntsGen
        }
 
 mkSetter

--- a/test/web3/Web3Spec/Live/Utils.purs
+++ b/test/web3/Web3Spec/Live/Utils.purs
@@ -2,7 +2,7 @@ module Web3Spec.Live.Utils where
 
 import Prelude
 
-import Control.Monad.Reader (ReaderT, ask, runReaderT)
+import Control.Monad.Reader (ReaderT, runReaderT)
 import Data.Array ((!!))
 import Data.ByteString as BS
 import Data.Either (Either(..))
@@ -15,9 +15,8 @@ import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff, Milliseconds(..), Fiber, joinFiber, delay)
 import Effect.Aff.AVar as AVar
 import Effect.Aff.Class (class MonadAff, liftAff)
-import Effect.Class (liftEffect)
 import Effect.Class.Console as C
-import Test.Spec (ComputationType(..), Spec, SpecT, hoistSpec)
+import Test.Spec (ComputationType(..), SpecT, hoistSpec)
 import Network.Ethereum.Core.BigNumber (decimal, parseBigNumber)
 import Network.Ethereum.Core.Signatures (mkAddress)
 import Network.Ethereum.Web3 (class EventFilter, class KnownSize, Address, Web3Error, BigNumber, BlockNumber, BytesN, CallError, DLProxy, EventAction(..), HexString, Provider, TransactionOptions, TransactionReceipt(..), TransactionStatus(..), UIntN, Web3, _from, _gas, defaultTransactionOptions, embed, event, eventFilter, forkWeb3', fromByteString, intNFromBigNumber, mkHexString, runWeb3, uIntNFromBigNumber)


### PR DESCRIPTION
This PR introduces the following (**breaking**) changes

1. Remove `Pending` and `Earliest` from `ChainCursor` constructors.
For `Earliest` this is not a big deal, it should have never been there. It's just some cute replacement for the `0` block number, and it encourages "more than one way to do something" which adds no value. 
For `Pending`, we never had correct behavior in the first place. For one thing, the coroutines were never set up for that. Another problem is that for pending blocks half of the fields in the `Change` type (e.g. blockNumber`) are null and would fail to parse anyway. See [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterchanges). I would propose that we put it back when we know how to do it right. 

2. Adds the `trailBy` as a event option.
This is similar to hs-web3. You can say that you would like to always trail by a certain number of blocks once you've "caught up"