### PR TITLE
Make eth_call polymorphic for TransactionOptions

### DIFF
--- a/src/Network/Ethereum/Web3/Api.purs
+++ b/src/Network/Ethereum/Web3/Api.purs
@@ -132,7 +132,7 @@ eth_getTransaction :: HexString -> Web3 Transaction
 eth_getTransaction hx = remote "eth_getTransactionByHash" hx
 
 -- | Call a function on a particular block's state root.
-eth_call :: TransactionOptions NoPay -> ChainCursor -> Web3 HexString
+eth_call :: forall a. TransactionOptions a -> ChainCursor -> Web3 HexString
 eth_call opts cm = remote "eth_call" opts cm
 
 -- | Creates new message call transaction or a contract creation, if the data field contains code.


### PR DESCRIPTION
## Purpose

`eth_call` can run a transaction to see whether a transaction will succeed or did succeed and return the result of the transaction which can include the reason for the revert if a solidity developer specifies a reason.

## Example

```solidity
function test() payable public {
  require(msg.value > 0, "msg.value too small");
  require(false, "this failed cuz this is always false");
}
```

Say I call `test()` with a transaction where I sent 2 eth. It would fail with message `this failed cuz this is always false`. However, if I want to use `eth_call` to get the reason, I'm restricted to only transactions with an empty `value` field. When if I attempt without any eth in transaction options so the message will always be `msg.value too small`, so I essentially tested a different transaction.

I made the `TransactionOptions NoPay` to be `forall. TransactionOptions a`. Maybe this is too flexible so would appreciate feedback.

Cheers!
Charles