### PR TITLE
support hooks when using multifilters/event'

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -146,6 +146,31 @@ let additions =
       , version =
           "v6.0.0"
       }
+  , option =
+      { dependencies =
+          [ "argonaut-codecs"
+          , "argonaut-core"
+          , "codec"
+          , "codec-argonaut"
+          , "either"
+          , "foreign"
+          , "foreign-object"
+          , "lists"
+          , "maybe"
+          , "profunctor"
+          , "prelude"
+          , "record"
+          , "simple-json"
+          , "transformers"
+          , "tuples"
+          , "type-equality"
+          , "unsafe-coerce"
+          ]
+      , repo =
+          "https://github.com/joneshf/purescript-option.git"
+      , version =
+          "v6.0.1"
+      }
   , tagged =
       { dependencies =
           [ "identity"

--- a/spago.dhall
+++ b/spago.dhall
@@ -19,6 +19,7 @@ You can edit this file as you like.
   , "free"
   , "heterogeneous"
   , "identity"
+  , "option"
   , "parsing"
   , "partial"
   , "profunctor-lenses"

--- a/src/Network/Ethereum/Web3/Api.purs
+++ b/src/Network/Ethereum/Web3/Api.purs
@@ -3,7 +3,7 @@ module Network.Ethereum.Web3.Api where
 import Data.Maybe (Maybe, fromMaybe)
 import Network.Ethereum.Types (Address, HexString, BigNumber)
 import Network.Ethereum.Web3.JsonRPC (remote)
-import Network.Ethereum.Web3.Types (Block, BlockNumber, ChainCursor, Change, FalseOrObject, Filter, FilterId, NoPay, SyncStatus, Transaction, TransactionOptions, TransactionReceipt, Web3)
+import Network.Ethereum.Web3.Types (Block, BlockNumber, ChainCursor, Change, FalseOrObject, Filter, FilterId, SyncStatus, Transaction, TransactionOptions, TransactionReceipt, Web3)
 import Network.Ethereum.Web3.Types.TokenUnit (MinorUnit)
 
 -- | Returns current node version string.

--- a/test/web3/Main.purs
+++ b/test/web3/Main.purs
@@ -42,8 +42,9 @@ main = launchAff_ do
       EtherUnitSpec.spec
     RPCSpec.spec p
     FilterSpec.spec p
-    -- payable spec can't be run in parallel :/
+    -- payable and multifilter spec can't be run in parallel :/
     PayableTestSpec.spec p
+    MultifilterSpec.spec p
     -- all of these tests only have one `it` statement and
     -- are dealing with separate contracts so they can be run
     -- in parallel
@@ -52,7 +53,6 @@ main = launchAff_ do
       ComplexStorageSpec.spec p
       MockERC20Spec.spec p
       SimpleErrorTestSpec.spec p
-      MultifilterSpec.spec p
   where
     hoist :: Spec ~> SpecT Aff Unit Aff
     hoist = mapSpecTree (pure <<< un Identity) identity

--- a/test/web3/Web3Spec/Live/MultifilterSpec.purs
+++ b/test/web3/Web3Spec/Live/MultifilterSpec.purs
@@ -2,33 +2,44 @@ module Web3Spec.Live.MultifilterSpec (spec) where
 
 import Prelude
 
-import Control.Monad.Reader (ask)
-import Data.Array (snoc, (..), length, sort)
-import Data.Bifunctor (rmap)
-import Data.Lens ((?~))
-import Data.Tuple (Tuple(..))
+import Control.Alt ((<|>))
+import Control.Monad.Reader (ask, lift)
 import Control.Parallel (parSequence_, parTraverse_)
+import Data.Array (elem, foldl, head, last, length, snoc, sort, unsnoc, (..))
+import Data.Bifunctor (rmap)
+import Data.Either (Either(..), either)
+import Data.Foldable (for_)
+import Data.Lens ((?~))
+import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing, maybe)
+import Data.Newtype (un)
+import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff)
-import Effect.Aff.Class (liftAff)
 import Effect.Aff.AVar as AVar
+import Effect.Aff.Class (liftAff)
 import Effect.Class.Console as C
+import Network.Ethereum.Web3 (BigNumber, BlockNumber(..), Change(..), EventAction(..), EventHandler, Provider, Value, Web3, Wei, _data, _from, _to, _value, embed, event, event', eventFilter, forkWeb3, mkValue)
+import Network.Ethereum.Web3.Api (eth_blockNumber)
 import Network.Ethereum.Web3.Api as Api
-import Network.Ethereum.Web3 (Provider, BlockNumber, EventHandler, Web3, event, event', BigNumber, forkWeb3, eventFilter, EventAction(..), Change(..), _data, _from, _to, _value, mkValue, Value, Wei)
 import Network.Ethereum.Web3.Solidity.Sizes (s256)
 import Test.Spec (SpecT, describe, it, beforeAll)
-import Test.Spec.Assertions (shouldEqual, shouldNotEqual)
+import Test.Spec.Assertions (shouldEqual, shouldNotEqual, shouldSatisfy)
 import Type.Proxy (Proxy(..))
-import Web3Spec.Live.Utils (deployContract, defaultTestTxOptions, mkUIntN, assertWeb3, joinWeb3Fork, awaitNextBlock)
 import Web3Spec.Live.Code.Multifilter as MultifilterCode
 import Web3Spec.Live.Contract.Multifilter as Multifilter
+import Web3Spec.Live.Utils (deployContract, defaultTestTxOptions, mkUIntN, assertWeb3, joinWeb3Fork, awaitNextBlock, hangOutTillBlock)
 
 spec :: Provider -> SpecT Aff Unit Aff Unit
 spec provider =
-  describe "Multifilter" $
+  describe "Multifilter" do
+    let pE1 = Proxy :: Proxy Multifilter.E1
+        pE2 = Proxy :: Proxy Multifilter.E2
+        fireE1 txOpts n = void $ assertWeb3 provider $ Multifilter.fireE1 txOpts {_value : mkUIntN s256 n}
+        fireE2 txOpts n = void $ assertWeb3 provider $ Multifilter.fireE2 txOpts {_value: mkUIntN s256 n}
+        logger = (liftAff <<< C.log)
     beforeAll ( deployContract provider C.log "Multifilter" $ \txOpts ->
                   Api.eth_sendTransaction $ txOpts # _data ?~ MultifilterCode.deployBytecode
                                                    # _value ?~ (mkValue zero :: Value Wei)
-              ) $
+              ) $ do
       it "can receive multiple events in the correct order" \contractCfg -> do
         let {contractAddress: multifilterAddress, userAddress} = contractCfg
             txOpts = defaultTestTxOptions
@@ -37,37 +48,35 @@ spec provider =
             vals1 = 1..5
             vals2 = 6..10
             nVals = length vals1 + length vals2
-            fireE1 n = void $ assertWeb3 provider $ Multifilter.fireE1 txOpts {_value : mkUIntN s256 n}
-            fireE2 n = void $ assertWeb3 provider $ Multifilter.fireE2 txOpts {_value: mkUIntN s256 n}
 
-            filter1 = eventFilter (Proxy :: Proxy Multifilter.E1) multifilterAddress
-            filter2 = eventFilter (Proxy :: Proxy Multifilter.E2) multifilterAddress
+            filter1 = eventFilter pE1 multifilterAddress
+            filter2 = eventFilter pE2 multifilterAddress
 
         raceV <- AVar.new []
 
         count1V <- AVar.new 0
         f1 <- forkWeb3 provider $ 
-          let h1 = mkHandler (Proxy :: Proxy Multifilter.E1) provider raceV count1V (_ == length vals1) true
+          let h1 = mkHandler pE1 provider raceV count1V (_ == length vals1) true
           in void $ event filter1 h1
 
         count2V <- AVar.new 0
         f2 <- forkWeb3 provider $ 
-          let h2 = mkHandler (Proxy :: Proxy Multifilter.E2) provider raceV count2V (_ == length vals2) false
+          let h2 = mkHandler pE2 provider raceV count2V (_ == length vals2) false
           in void $ event filter2 h2
 
         syncV <- AVar.new []
         sharedCountV <- AVar.new 0
         let multiFilter = { e1 : filter1, e2 : filter2}
-            h1 = mkHandler (Proxy :: Proxy Multifilter.E1) provider syncV sharedCountV (_ == nVals) true
-            h2 = mkHandler (Proxy :: Proxy Multifilter.E2) provider syncV sharedCountV (_ == nVals) false
+            h1 = mkHandler pE1 provider syncV sharedCountV (_ == nVals) true
+            h2 = mkHandler pE2 provider syncV sharedCountV (_ == nVals) false
             multiHandler = {e1: h1, e2: h2}
         f3 <- do
           f <- forkWeb3 provider $ event' multiFilter multiHandler {trailBy: 0, windowSize: 0}
           pure $ (rmap (const unit) <$> f)
 
         parSequence_ $
-          [ parTraverse_ fireE1 vals1
-          , parTraverse_ fireE2 vals2
+          [ parTraverse_ (fireE1 txOpts) vals1
+          , parTraverse_ (fireE2 txOpts) vals2
           ]
 
         parTraverse_ joinWeb3Fork [f1, f2, f3]
@@ -78,6 +87,158 @@ spec provider =
         race `shouldNotEqual` sync
         sort race `shouldEqual` sync
         sort sync `shouldEqual` sync
+
+      it "optional multifilter hooks don't break type inference" \{contractAddress} -> do
+        let dummyEvent'NoEvents1 = event' { } { } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'NoEvents2 = event' { } { } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'NoEvents3 = event' { } { } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit), afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'NoEvents4 = event' { } { } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit), beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'NoEvents5 = event' { } { } { afterFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'NoEvents6 = event' { } { } { beforeFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'NoEvents7 = event' { } { } { trailBy: 0, beforeFilterWindow: (\_ -> pure unit), windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'NoEvents8 = event' { } { } { trailBy: 0, afterFilterWindow: (\_ -> pure unit), windowSize: 0 }
+
+            f1 = eventFilter pE1 contractAddress
+            f2 = eventFilter pE2 contractAddress
+            h1 = dummyHandler pE1 Nothing
+            h2 = dummyHandler pE2 Nothing
+
+            dummyEvent'OneEvent1 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'OneEvent2 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'OneEvent3 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit), afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'OneEvent4 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit), beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'OneEvent5 = event' { f1 } { f1: h1 } { afterFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'OneEvent6 = event' { f1 } { f1: h1 } { beforeFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'OneEvent7 = event' { f1 } { f1: h1 } { trailBy: 0, beforeFilterWindow: (\_ -> pure unit), windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'OneEvent8 = event' { f1 } { f1: h1 } { trailBy: 0, afterFilterWindow: (\_ -> pure unit), windowSize: 0 }
+
+            dummyEvent'TwoEvents1 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'TwoEvents2 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'TwoEvents3 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit), afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'TwoEvents4 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit), beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'TwoEvents5 = event' { f1, f2 } { f1: h1, f2: h2 } { afterFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
+            dummyEvent'TwoEvents6 = event' { f1, f2 } { f1: h1, f2: h2 } { beforeFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'TwoEvents7 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, beforeFilterWindow: (\_ -> pure unit), windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
+            dummyEvent'TwoEvents8 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, afterFilterWindow: (\_ -> pure unit), windowSize: 0 }
+        pure unit
+
+      it "actually runs before and after hooks in proper order" \{contractAddress, userAddress} -> do
+        (BlockNumber startBlock) <- assertWeb3 provider eth_blockNumber
+        hooksAndEventsV <- AVar.new []
+        counterV <- AVar.new 0
+        let endBlock = startBlock + (embed 10)
+            endBlock' = endBlock + (embed 3)
+            storeFW when = storeHookValue hooksAndEventsV counterV (\{ counter, v } -> { counter, v: Left { when, v } })
+            multiFilter = { e1: eventFilter pE1 contractAddress, e2: eventFilter pE2 contractAddress}
+            evs = 1..5
+            storeEV :: forall ev. Proxy ev -> EventHandler Web3 ev
+            storeEV p = storeEventValue p hooksAndEventsV counterV (\{ counter, change } -> { counter, v: Right change }) (Just endBlock)
+            multiHandler = { e1: storeEV pE1, e2: storeEV pE2 }
+            txOpts = defaultTestTxOptions
+                       # _from ?~ userAddress
+                       # _to ?~ contractAddress
+
+        f <- forkWeb3 provider $ event' multiFilter multiHandler
+          { trailBy: 0
+          , windowSize: 0
+          , beforeFilterWindow: storeFW "before"
+          , afterFilterWindow: storeFW "after"
+          , onFilterTermination: \cr -> storeFW "filter_term" { start: cr.blockNumber, end: cr.blockNumber }
+          }
+        for_ evs $ \n -> fireE1 txOpts n *> fireE2 txOpts n *> awaitNextBlock provider logger
+        hangOutTillBlock provider logger (BlockNumber endBlock)
+
+        -- fire one more set of events so the filters terminate...
+        fireE1 txOpts 99
+        fireE2 txOpts 99
+
+        void $ joinWeb3Fork f
+        hooksAndEvents <- AVar.take hooksAndEventsV
+
+        let evAsBeforeHook { counter,  v: Left { when: "before", v } } = Just { counter, v }
+            evAsBeforeHook _ = Nothing
+
+            evAsAfterHook { counter,  v: Left { when: "after", v } } = Just { counter, v }
+            evAsAfterHook _ = Nothing
+
+            evAsFilterTermHook { counter,  v: Left { when: "filter_term", v } } = Just { counter, v }
+            evAsFilterTermHook _ = Nothing
+
+            snoc' complete pending = if pending == [] then complete else snoc complete pending
+
+            chainFolder st@{ complete, pending } ev = case ev of
+              { v: Left { when: "before" } } -> { complete: snoc' complete pending, pending: [ev] }
+              { v: Left { when: "after" } }  -> { complete: snoc complete (snoc pending ev), pending: [] }
+              { v: Left { when: "filter_term" } } -> { complete: snoc complete (snoc pending ev), pending: [] }
+              _ -> st { pending = snoc pending ev }
+            chains = foldl chainFolder { complete: [], pending: [] } hooksAndEvents
+
+        for_ chains.complete $ \chain -> do
+          let start = evAsBeforeHook =<< head chain
+              end = evAsAfterHook =<< last chain
+              end' = evAsFilterTermHook =<< last chain
+              consecFolder { prevBN, prevCounter, isConsecutiveCounter, isConsecutiveBN } curr =
+                let { counter, bn } =
+                      case curr of
+                        { counter, v: Right (Change { blockNumber: (BlockNumber bn) }) } -> { counter, bn }
+                        { counter, v: Left { when: "before", v: { start } } } -> { counter, bn: un BlockNumber start }
+                        { counter, v: Left { when: "after", v: { end } } } -> { counter, bn: un BlockNumber end }
+                        { counter } -> { counter, bn: embed 0 } -- ok to ignore when "filter_term" -- we drop it in `chainToFold`
+                    consCounter' = isConsecutiveCounter && (counter >= prevCounter)
+                    consBN' = isConsecutiveBN && (bn >= prevBN)
+                 in { prevBN: bn, prevCounter: counter, isConsecutiveCounter: consCounter', isConsecutiveBN: consBN' }
+
+              chainToFold = if isJust end' then fromMaybe [] (_.init <$> unsnoc chain) else chain
+              evsConsecutive = foldl consecFolder { prevBN: embed 0, prevCounter: -1, isConsecutiveCounter: true, isConsecutiveBN: true } chainToFold
+
+          start `shouldSatisfy` isJust
+
+          if isNothing end'
+          then end `shouldSatisfy` isJust
+          else end' `shouldSatisfy` isJust
+
+          evsConsecutive `shouldSatisfy` _.isConsecutiveCounter
+          evsConsecutive `shouldSatisfy` _.isConsecutiveBN
+
+        chains.pending `shouldEqual` []
+
+dummyHandler :: forall e. Proxy e -> Maybe BigNumber -> EventHandler Web3 e
+dummyHandler _ Nothing _ = pure TerminateEvent
+dummyHandler _ (Just bn) _ = (\(BlockNumber x) -> if x >= bn then TerminateEvent else ContinueEvent) <$> lift eth_blockNumber
+
+storeHookValue
+  :: forall a e.
+     AVar.AVar (Array e)
+  -> AVar.AVar Int
+  -> ({ counter :: Int, v :: a } -> e)
+  -> a
+  -> Web3 Unit
+storeHookValue avar counterVar hook2e v = liftAff $ do
+  counter <- do
+    originalVal <- AVar.take counterVar
+    AVar.put (originalVal + 1) counterVar
+    pure originalVal
+  av <- AVar.take avar
+  AVar.put (snoc av (hook2e { counter, v })) avar
+
+storeEventValue
+  :: forall a e
+   . Proxy a
+  -> AVar.AVar (Array e)
+  -> AVar.AVar Int
+  -> ({ counter :: Int, change :: Change, ev :: a } -> e)
+  -> Maybe BigNumber
+  -> EventHandler Web3 a
+storeEventValue pa avar counterVar ev2e terminateBlock ev = do
+  change <- ask
+  liftAff do
+    counter <- do
+      originalVal <- AVar.take counterVar
+      AVar.put (originalVal + 1) counterVar
+      pure originalVal
+    av <- AVar.take avar
+    AVar.put (snoc av (ev2e { counter, change, ev })) avar
+  dummyHandler pa terminateBlock ev
 
 mkHandler
   :: forall e.

--- a/test/web3/Web3Spec/Live/MultifilterSpec.purs
+++ b/test/web3/Web3Spec/Live/MultifilterSpec.purs
@@ -2,15 +2,14 @@ module Web3Spec.Live.MultifilterSpec (spec) where
 
 import Prelude
 
-import Control.Alt ((<|>))
 import Control.Monad.Reader (ask, lift)
 import Control.Parallel (parSequence_, parTraverse_)
-import Data.Array (elem, foldl, head, last, length, snoc, sort, unsnoc, (..))
+import Data.Array (foldl, head, last, length, snoc, sort, unsnoc, (..))
 import Data.Bifunctor (rmap)
-import Data.Either (Either(..), either)
+import Data.Either (Either(..))
 import Data.Foldable (for_)
 import Data.Lens ((?~))
-import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing, maybe)
+import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing)
 import Data.Newtype (un)
 import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff)

--- a/test/web3/Web3Spec/Live/MultifilterSpec.purs
+++ b/test/web3/Web3Spec/Live/MultifilterSpec.purs
@@ -4,12 +4,12 @@ import Prelude
 
 import Control.Monad.Reader (ask, lift)
 import Control.Parallel (parSequence_, parTraverse_)
-import Data.Array (foldl, head, last, length, snoc, sort, unsnoc, (..))
+import Data.Array (foldl, length, snoc, sort, (..))
 import Data.Bifunctor (rmap)
 import Data.Either (Either(..))
 import Data.Foldable (for_)
 import Data.Lens ((?~))
-import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (un)
 import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff)
@@ -20,7 +20,7 @@ import Network.Ethereum.Web3 (BigNumber, BlockNumber(..), Change(..), EventActio
 import Network.Ethereum.Web3.Api (eth_blockNumber)
 import Network.Ethereum.Web3.Api as Api
 import Network.Ethereum.Web3.Solidity.Sizes (s256)
-import Test.Spec (SpecT, describe, it, beforeAll)
+import Test.Spec (SpecT, beforeAll, describe, it)
 import Test.Spec.Assertions (shouldEqual, shouldNotEqual, shouldSatisfy)
 import Type.Proxy (Proxy(..))
 import Web3Spec.Live.Code.Multifilter as MultifilterCode
@@ -88,37 +88,37 @@ spec provider =
         sort sync `shouldEqual` sync
 
       it "optional multifilter hooks don't break type inference" \{contractAddress} -> do
-        let dummyEvent'NoEvents1 = event' { } { } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'NoEvents2 = event' { } { } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'NoEvents3 = event' { } { } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit), afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'NoEvents4 = event' { } { } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit), beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'NoEvents5 = event' { } { } { afterFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'NoEvents6 = event' { } { } { beforeFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'NoEvents7 = event' { } { } { trailBy: 0, beforeFilterWindow: (\_ -> pure unit), windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'NoEvents8 = event' { } { } { trailBy: 0, afterFilterWindow: (\_ -> pure unit), windowSize: 0 }
+        let dummyEvent'NoEvents1 = event' { } { } { trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'NoEvents2 = event' { } { } { trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit) }
+            dummyEvent'NoEvents3 = event' { } { } { trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit), afterEvent: (\_ -> pure unit) }
+            dummyEvent'NoEvents4 = event' { } { } { trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit), beforeEvent: (\_ -> pure unit) }
+            dummyEvent'NoEvents5 = event' { } { } { afterEvent: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit) }
+            dummyEvent'NoEvents6 = event' { } { } { beforeEvent: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'NoEvents7 = event' { } { } { trailBy: 0, beforeEvent: (\_ -> pure unit), windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'NoEvents8 = event' { } { } { trailBy: 0, afterEvent: (\_ -> pure unit), windowSize: 0 }
 
             f1 = eventFilter pE1 contractAddress
             f2 = eventFilter pE2 contractAddress
             h1 = dummyHandler pE1 Nothing
             h2 = dummyHandler pE2 Nothing
 
-            dummyEvent'OneEvent1 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'OneEvent2 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'OneEvent3 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit), afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'OneEvent4 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit), beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'OneEvent5 = event' { f1 } { f1: h1 } { afterFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'OneEvent6 = event' { f1 } { f1: h1 } { beforeFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'OneEvent7 = event' { f1 } { f1: h1 } { trailBy: 0, beforeFilterWindow: (\_ -> pure unit), windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'OneEvent8 = event' { f1 } { f1: h1 } { trailBy: 0, afterFilterWindow: (\_ -> pure unit), windowSize: 0 }
+            dummyEvent'OneEvent1 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'OneEvent2 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit) }
+            dummyEvent'OneEvent3 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit), afterEvent: (\_ -> pure unit) }
+            dummyEvent'OneEvent4 = event' { f1 } { f1: h1 } { trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit), beforeEvent: (\_ -> pure unit) }
+            dummyEvent'OneEvent5 = event' { f1 } { f1: h1 } { afterEvent: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit) }
+            dummyEvent'OneEvent6 = event' { f1 } { f1: h1 } { beforeEvent: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'OneEvent7 = event' { f1 } { f1: h1 } { trailBy: 0, beforeEvent: (\_ -> pure unit), windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'OneEvent8 = event' { f1 } { f1: h1 } { trailBy: 0, afterEvent: (\_ -> pure unit), windowSize: 0 }
 
-            dummyEvent'TwoEvents1 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'TwoEvents2 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'TwoEvents3 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit), afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'TwoEvents4 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit), beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'TwoEvents5 = event' { f1, f2 } { f1: h1, f2: h2 } { afterFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeFilterWindow: (\_ -> pure unit) }
-            dummyEvent'TwoEvents6 = event' { f1, f2 } { f1: h1, f2: h2 } { beforeFilterWindow: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'TwoEvents7 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, beforeFilterWindow: (\_ -> pure unit), windowSize: 0, afterFilterWindow: (\_ -> pure unit) }
-            dummyEvent'TwoEvents8 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, afterFilterWindow: (\_ -> pure unit), windowSize: 0 }
+            dummyEvent'TwoEvents1 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'TwoEvents2 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit) }
+            dummyEvent'TwoEvents3 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit), afterEvent: (\_ -> pure unit) }
+            dummyEvent'TwoEvents4 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit), beforeEvent: (\_ -> pure unit) }
+            dummyEvent'TwoEvents5 = event' { f1, f2 } { f1: h1, f2: h2 } { afterEvent: (\_ -> pure unit), trailBy: 0, windowSize: 0, beforeEvent: (\_ -> pure unit) }
+            dummyEvent'TwoEvents6 = event' { f1, f2 } { f1: h1, f2: h2 } { beforeEvent: (\_ -> pure unit), trailBy: 0, windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'TwoEvents7 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, beforeEvent: (\_ -> pure unit), windowSize: 0, afterEvent: (\_ -> pure unit) }
+            dummyEvent'TwoEvents8 = event' { f1, f2 } { f1: h1, f2: h2 } { trailBy: 0, afterEvent: (\_ -> pure unit), windowSize: 0 }
         pure unit
 
       it "actually runs before and after hooks in proper order" \{contractAddress, userAddress} -> do
@@ -126,7 +126,6 @@ spec provider =
         hooksAndEventsV <- AVar.new []
         counterV <- AVar.new 0
         let endBlock = startBlock + (embed 10)
-            endBlock' = endBlock + (embed 3)
             storeFW when = storeHookValue hooksAndEventsV counterV (\{ counter, v } -> { counter, v: Left { when, v } })
             multiFilter = { e1: eventFilter pE1 contractAddress, e2: eventFilter pE2 contractAddress}
             evs = 1..5
@@ -140,64 +139,49 @@ spec provider =
         f <- forkWeb3 provider $ event' multiFilter multiHandler
           { trailBy: 0
           , windowSize: 0
-          , beforeFilterWindow: storeFW "before"
-          , afterFilterWindow: storeFW "after"
+          , beforeFilterWindow: storeFW "before_window"
+          , beforeEvent: \(Change c) -> storeFW "before_event" { start: c.blockNumber, end: c.blockNumber }
+          , afterEvent: \(Change c) -> storeFW "after_event" { start: c.blockNumber, end: c.blockNumber }
           , onFilterTermination: \cr -> storeFW "filter_term" { start: cr.blockNumber, end: cr.blockNumber }
           }
         for_ evs $ \n -> fireE1 txOpts n *> fireE2 txOpts n *> awaitNextBlock provider logger
         hangOutTillBlock provider logger (BlockNumber endBlock)
 
-        -- fire one more set of events so the filters terminate...
+        -- fire one more set of events so the filters terminate
+        -- the event handlers don't store any events triggered after endBlock
         fireE1 txOpts 99
         fireE2 txOpts 99
 
         void $ joinWeb3Fork f
         hooksAndEvents <- AVar.take hooksAndEventsV
 
-        let evAsBeforeHook { counter,  v: Left { when: "before", v } } = Just { counter, v }
-            evAsBeforeHook _ = Nothing
-
-            evAsAfterHook { counter,  v: Left { when: "after", v } } = Just { counter, v }
-            evAsAfterHook _ = Nothing
-
-            evAsFilterTermHook { counter,  v: Left { when: "filter_term", v } } = Just { counter, v }
-            evAsFilterTermHook _ = Nothing
-
-            snoc' complete pending = if pending == [] then complete else snoc complete pending
-
+        let snoc' complete pending = if pending == [] then complete else snoc complete pending
             chainFolder st@{ complete, pending } ev = case ev of
-              { v: Left { when: "before" } } -> { complete: snoc' complete pending, pending: [ev] }
-              { v: Left { when: "after" } }  -> { complete: snoc complete (snoc pending ev), pending: [] }
-              { v: Left { when: "filter_term" } } -> { complete: snoc complete (snoc pending ev), pending: [] }
+              { v: Left { when: "before_event" } } -> { complete: snoc' complete pending, pending: [ev] }
+              { v: Left { when: "after_event" } } -> { complete: snoc' complete (snoc pending ev), pending: [] }
+              { v: Left _ } -> st -- drop before_windows and filter_terms
               _ -> st { pending = snoc pending ev }
             chains = foldl chainFolder { complete: [], pending: [] } hooksAndEvents
 
         for_ chains.complete $ \chain -> do
-          let start = evAsBeforeHook =<< head chain
-              end = evAsAfterHook =<< last chain
-              end' = evAsFilterTermHook =<< last chain
-              consecFolder { prevBN, prevCounter, isConsecutiveCounter, isConsecutiveBN } curr =
+          let bnZero = embed 0
+              consecFolder { prevBN, prevCounter, isConsecutiveCounter, isSameBN } curr =
                 let { counter, bn } =
                       case curr of
                         { counter, v: Right (Change { blockNumber: (BlockNumber bn) }) } -> { counter, bn }
-                        { counter, v: Left { when: "before", v: { start } } } -> { counter, bn: un BlockNumber start }
-                        { counter, v: Left { when: "after", v: { end } } } -> { counter, bn: un BlockNumber end }
+                        { counter, v: Left { when: "before_window", v: { start } } } -> { counter, bn: un BlockNumber start }
+                        { counter, v: Left { when: "before_event", v: { start } } } -> { counter, bn: un BlockNumber start }
+                        { counter, v: Left { when: "after_event", v: { end } } } -> { counter, bn: un BlockNumber end }
                         { counter } -> { counter, bn: embed 0 } -- ok to ignore when "filter_term" -- we drop it in `chainToFold`
                     consCounter' = isConsecutiveCounter && (counter >= prevCounter)
-                    consBN' = isConsecutiveBN && (bn >= prevBN)
-                 in { prevBN: bn, prevCounter: counter, isConsecutiveCounter: consCounter', isConsecutiveBN: consBN' }
+                    sameBN' = isSameBN && (prevBN == bnZero || bn == prevBN) -- handle the "first thing in the change not being == 0" case
+                 in { prevBN: bn, prevCounter: counter, isConsecutiveCounter: consCounter', isSameBN: sameBN' }
 
-              chainToFold = if isJust end' then fromMaybe [] (_.init <$> unsnoc chain) else chain
-              evsConsecutive = foldl consecFolder { prevBN: embed 0, prevCounter: -1, isConsecutiveCounter: true, isConsecutiveBN: true } chainToFold
+              evsConsec = foldl consecFolder { prevBN: bnZero, prevCounter: -1, isConsecutiveCounter: true, isSameBN: true } chain
 
-          start `shouldSatisfy` isJust
-
-          if isNothing end'
-          then end `shouldSatisfy` isJust
-          else end' `shouldSatisfy` isJust
-
-          evsConsecutive `shouldSatisfy` _.isConsecutiveCounter
-          evsConsecutive `shouldSatisfy` _.isConsecutiveBN
+          -- done like this so you can see the chain when it fails...
+          { evsConsec, chain } `shouldSatisfy` _.evsConsec.isConsecutiveCounter
+          { evsConsec, chain } `shouldSatisfy` _.evsConsec.isSameBN
 
         chains.pending `shouldEqual` []
 
@@ -229,8 +213,9 @@ storeEventValue
   -> Maybe BigNumber
   -> EventHandler Web3 a
 storeEventValue pa avar counterVar ev2e terminateBlock ev = do
-  change <- ask
-  liftAff do
+  change@(Change { blockNumber: (BlockNumber changeBN )}) <- ask
+  let shouldStore = fromMaybe true $ (changeBN <= _) <$> terminateBlock
+  when shouldStore $ liftAff do
     counter <- do
       originalVal <- AVar.take counterVar
       AVar.put (originalVal + 1) counterVar


### PR DESCRIPTION
This expands the functionality of `event'` by allowing you to add hooks that run at certain parts of the `event'` lifecycle. Currently three are implemented -- notifying you when when a new filter window is about to be queried, after a filter window has finished querying, and when a filter has terminated the `event'` loop via a `TerminateEvent`.

Naturally, this is very handy when writing chain indexers, as you can have a checkpointing system that doesn't just checkpoint at the last event seen. If on-chain interaction with your target contracts is sparse, this could mean you checkpoint very far from the chain head and have to wait to a long time to catch up to chain head when restarting from a checkpoint. Previously, the alternative was to somehow hook your `Provider` and intercept `eth_getLogs` calls -- which is pretty lame and unreliable. Now, you can get indexing progress straight from the horse's mouth. 

Using [`option`](https://github.com/joneshf/purescript-option), we can actually make all of these hooks as "optional" keys to the `event'` arguments record (which was originally used only for filter window parameters) -- i.e., you don't have to supply a record containing `hookYouDontCareAbout: Nothing` -- so no need to have a `defaultEvent'Args { fieldsYouCareAboutSetting }` either.

In other words, this PR does not break the existing API, and adding more hooks in the future won't either.

Tests are included to ensure that using `Option` won't break any type inference of existing `event'` use sites, as well as tests to ensure that the hooks run in the expected order.

In principle, this could be expanded to the regular (single-filter) `event` function as well since it's a single-filter MultiFilter under the hood, but that would actually require breaking API changes, and doesn't seem worth it anyway (i.e., if you're just polling a single event, you probably don't care about checkpointing, and someone who really cares about both can just construct a single-event multifilter)