### PR TITLE
Missing instances

### DIFF
--- a/src/Network/Ethereum/Web3/Api.purs
+++ b/src/Network/Ethereum/Web3/Api.purs
@@ -3,7 +3,7 @@ module Network.Ethereum.Web3.Api where
 import Data.Maybe (Maybe, fromMaybe)
 import Network.Ethereum.Types (Address, HexString, BigNumber)
 import Network.Ethereum.Web3.JsonRPC (remote)
-import Network.Ethereum.Web3.Types (Block, BlockNumber, ChainCursor, Change, FalseOrObject, Filter, FilterId, NoPay, SyncStatus, Transaction, TransactionOptions, TransactionReceipt, Web3)
+import Network.Ethereum.Web3.Types (Block, BlockNumber, ChainCursor, Change, FalseOrObject, Filter, FilterId, SyncStatus, Transaction, TransactionOptions, TransactionReceipt, Web3)
 import Network.Ethereum.Web3.Types.TokenUnit (MinorUnit)
 
 -- | Returns current node version string.

--- a/src/Network/Ethereum/Web3/Solidity/Bytes.purs
+++ b/src/Network/Ethereum/Web3/Solidity/Bytes.purs
@@ -7,13 +7,10 @@ module Network.Ethereum.Web3.Solidity.Bytes
   ) where
 
 import Prelude
-import Data.ByteString (empty, ByteString, Encoding(Hex))
-import Data.ByteString as BS
-import Data.Maybe (Maybe(..), fromJust)
+import Data.ByteString (ByteString)
+import Data.Maybe (Maybe(..))
 import Network.Ethereum.Core.HexString as Hex
-import Network.Ethereum.Types (mkHexString)
 import Network.Ethereum.Web3.Solidity.Size (class KnownSize, DLProxy(..), sizeVal, kind DigitList)
-import Partial.Unsafe (unsafePartial)
 
 --------------------------------------------------------------------------------
 -- * Statically sized byte array
@@ -21,33 +18,31 @@ import Partial.Unsafe (unsafePartial)
 -- Represents a statically sized bytestring of size `n` bytes.
 -- | See module [Network.Ethereum.Web3.Solidity.Sizes](/Network.Ethereum.Web3.Solidity.Sizes) for some predefined sizes.
 newtype BytesN (n :: DigitList)
-  = BytesN ByteString
+  = BytesN Hex.HexString
 
 derive newtype instance eqBytesN :: Eq (BytesN n)
 
-instance showBytesN :: KnownSize n => Show (BytesN n) where
-  show (BytesN bs) = show <<< unsafePartial fromJust <<< mkHexString $ BS.toString bs Hex
+derive newtype instance showBytesN :: Show (BytesN n)
 
 derive newtype instance ordBytesN :: Ord (BytesN n)
 
 -- | Access the underlying raw bytestring
 unBytesN :: forall n. KnownSize n => BytesN n -> ByteString
-unBytesN (BytesN bs) = bs
+unBytesN (BytesN bs) = Hex.toByteString bs
 
 proxyBytesN :: forall n. KnownSize n => BytesN n
-proxyBytesN = BytesN empty
+proxyBytesN = BytesN mempty
 
 update :: forall n. KnownSize n => BytesN n -> ByteString -> BytesN n
-update _ = BytesN
+update _ = BytesN <<< Hex.fromByteString
 
 -- | Attempt to coerce a bytestring into one of the appropriate size.
 -- | See module [Network.Ethereum.Web3.Solidity.Sizes](/Network.Ethereum.Web3.Solidity.Sizes) for some predefined sizes.
 fromByteString :: forall n. KnownSize n => DLProxy n -> ByteString -> Maybe (BytesN n)
 fromByteString _ bs =
-  if not $ BS.length bs <= sizeVal (DLProxy :: DLProxy n) then
+  if not $ (Hex.hexLength h / 2) <= sizeVal (DLProxy :: DLProxy n) then
     Nothing
   else
-    let
-      padded = Hex.toByteString <<< Hex.padLeft <<< Hex.fromByteString $ bs
-    in
-      Just $ BytesN padded
+    Just $ BytesN h
+  where
+  h = Hex.fromByteString bs

--- a/src/Network/Ethereum/Web3/Solidity/Bytes.purs
+++ b/src/Network/Ethereum/Web3/Solidity/Bytes.purs
@@ -10,8 +10,9 @@ import Prelude
 import Data.ByteString (empty, ByteString, Encoding(Hex))
 import Data.ByteString as BS
 import Data.Maybe (Maybe(..), fromJust)
-import Network.Ethereum.Web3.Solidity.Size (class KnownSize, DLProxy(..), sizeVal, kind DigitList)
+import Network.Ethereum.Core.HexString as Hex
 import Network.Ethereum.Types (mkHexString)
+import Network.Ethereum.Web3.Solidity.Size (class KnownSize, DLProxy(..), sizeVal, kind DigitList)
 import Partial.Unsafe (unsafePartial)
 
 --------------------------------------------------------------------------------
@@ -26,6 +27,8 @@ derive newtype instance eqBytesN :: Eq (BytesN n)
 
 instance showBytesN :: KnownSize n => Show (BytesN n) where
   show (BytesN bs) = show <<< unsafePartial fromJust <<< mkHexString $ BS.toString bs Hex
+
+derive newtype instance ordBytesN :: Ord (BytesN n)
 
 -- | Access the underlying raw bytestring
 unBytesN :: forall n. KnownSize n => BytesN n -> ByteString
@@ -44,4 +47,7 @@ fromByteString _ bs =
   if not $ BS.length bs <= sizeVal (DLProxy :: DLProxy n) then
     Nothing
   else
-    Just $ BytesN bs
+    let
+      padded = Hex.toByteString <<< Hex.padLeft <<< Hex.fromByteString $ bs
+    in
+      Just $ BytesN padded

--- a/src/Network/Ethereum/Web3/Types/TokenUnit.purs
+++ b/src/Network/Ethereum/Web3/Types/TokenUnit.purs
@@ -48,6 +48,8 @@ derive newtype instance showValue :: Show (Value a)
 
 derive newtype instance decodeValue :: Decode (Value a)
 
+derive newtype instance ordValue :: Ord (Value a)
+
 instance encodeNoPay :: Encode (Value (NoPay t)) where
   encode _ = encode (zero :: BigNumber)
 else instance encodeValue :: Encode (Value a) where


### PR DESCRIPTION
fixes #112 

also use `HexString` as the type underlying `BytesN` rather than reimplementing that in the module