### PR TITLE
rethrow web3 error

### DIFF
--- a/src/Network/Ethereum/Web3/Contract.purs
+++ b/src/Network/Ethereum/Web3/Contract.purs
@@ -11,13 +11,14 @@ module Network.Ethereum.Web3.Contract
   ) where
 
 import Prelude
+
+import Control.Monad.Error.Class (throwError)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Functor.Tagged (Tagged, untagged)
 import Data.Generic.Rep (class Generic, Constructor)
 import Data.Lens ((.~), (%~), (?~))
 import Data.Maybe (Maybe(..))
-import Type.Proxy (Proxy(..))
 import Data.Symbol (class IsSymbol, reflectSymbol)
 import Effect.Exception (error)
 import Network.Ethereum.Core.Keccak256 (toSelector)
@@ -25,7 +26,8 @@ import Network.Ethereum.Types (Address, HexString)
 import Network.Ethereum.Web3.Api (eth_call, eth_sendTransaction)
 import Network.Ethereum.Web3.Contract.Events (MultiFilterStreamState(..), event', FilterStreamState, ChangeReceipt, EventHandler)
 import Network.Ethereum.Web3.Solidity (class DecodeEvent, class GenericABIDecode, class GenericABIEncode, class RecordFieldsIso, genericABIEncode, genericFromData, genericFromRecordFields)
-import Network.Ethereum.Web3.Types (class TokenUnit, CallError(..), ChainCursor, ETHER, Filter, NoPay, TransactionOptions, Value, Web3, _data, _value, convert, throwWeb3)
+import Network.Ethereum.Web3.Types (class TokenUnit, CallError(..), ChainCursor, ETHER, Filter, NoPay, TransactionOptions, Value, Web3, _data, _value, convert)
+import Type.Proxy (Proxy(..))
 
 class EventFilter :: forall k. k -> Constraint
 class EventFilter e where
@@ -133,7 +135,7 @@ _call txOptions cursor dat = do
               , _data: fullData
               }
       else
-        throwWeb3 <<< error $ show err
+        throwError $ error $ show err
     Right x -> pure $ Right x
   where
   txdata d = txOptions # _data .~ Just d

--- a/src/Network/Ethereum/Web3/JsonRPC.purs
+++ b/src/Network/Ethereum/Web3/JsonRPC.purs
@@ -1,19 +1,18 @@
 module Network.Ethereum.Web3.JsonRPC where
 
 import Prelude
-import Effect.Aff (Aff, Error, attempt, error)
-import Effect.Aff.Class (liftAff)
-import Effect.Aff.Compat (fromEffectFnAff, EffectFnAff)
-import Control.Monad.Error.Class (throwError)
+
 import Control.Monad.Except (runExcept)
 import Control.Monad.Reader (ask)
 import Data.Array ((:))
 import Data.Either (Either(..))
+import Effect.Aff (Aff, attempt)
+import Effect.Aff.Class (liftAff)
+import Effect.Aff.Compat (fromEffectFnAff, EffectFnAff)
 import Foreign (Foreign)
--- import Foreign.Generic (defaultOptions, genericEncodeJSON)
-import Network.Ethereum.Web3.Types (MethodName, Request, Response(..), Web3, Web3Error(..), mkRequest)
+import Network.Ethereum.Web3.Types (MethodName, Request, Response(..), Web3, Web3Error(..), mkRequest, throwWeb3)
 import Network.Ethereum.Web3.Types.Provider (Provider)
-import Simple.JSON (class ReadForeign, class WriteForeign, readImpl, writeImpl, writeJSON)
+import Simple.JSON (class ReadForeign, class WriteForeign, readImpl, writeImpl)
 
 --------------------------------------------------------------------------------
 -- * Asynchronous RPC Calls
@@ -27,18 +26,13 @@ instance ReadForeign a => Remote (Web3 a) where
     p <- ask
     res' <- liftAff $ attempt $ f p mempty
     case res' of
-      Left uncheckedErr -> throwError $ asError $ RemoteError $ show uncheckedErr
+      Left uncheckedErr -> throwWeb3 $ RemoteError (show uncheckedErr)
       Right res -> case runExcept $ readImpl res of
         -- case where we get either a known Web3Error or a foreign value
-        Left err -> throwError $ asError $ ParserError $ show err
+        Left err -> throwWeb3 $ ParserError $ show err
         Right (Response r) -> case r of
-          Left err -> throwError $ asError err
+          Left err -> throwWeb3 err
           Right a -> pure a
-    where
-    -- NOTE: this is a bit hacky
-    -- see Network.Ethereum.Web3.Types.Types#parseMsg
-    asError :: Web3Error -> Error
-    asError e = error $ writeJSON e
 
 instance (WriteForeign a, Remote b) => Remote (a -> b) where
   remote_ f x = remote_ $ \p args -> f p (writeImpl x : args)


### PR DESCRIPTION
prevent leaking the fact that we encode web3 errors as `Error` via json strings